### PR TITLE
Descrizione cospan generico

### DIFF
--- a/cap/01-categorie.tex
+++ b/cap/01-categorie.tex
@@ -296,7 +296,7 @@ Alcune categorie che è spesso utile considerare si rappresentano mediante dei g
 		\end{tikzcd}\]
 	La composizione è definita solamente quando almeno una delle due frecce è identica, ed è forzata da questo fatto.
 
-	Dualmente, la categoria `cospan generico' \(\Lambda^2_2\) ha tre oggetti \(0,1,2\) ma i due morfismi non identici escono da \(0\) invece che puntare verso \(2\):
+	Dualmente, la categoria `cospan generico' \(\Lambda^2_2\) ha tre oggetti \(0,1,2\) ma i due morfismi non identici puntano verso \(2\) invece che uscire da \(0\):
 	\[\begin{tikzcd}
 			0\ar[r] & 2 & 1\ar[l]
 		\end{tikzcd}\]


### PR DESCRIPTION
La descrizione era sbagliata; corretta.