### PR TITLE
Categoria libera su grafo

### DIFF
--- a/cap/01-categorie.tex
+++ b/cap/01-categorie.tex
@@ -380,14 +380,23 @@ Questi ultimi esempi lasciano supporre che \emph{ogni} grafo \(\ctG\), fatto di 
 	Un \emph{multidigrafo} consiste di una coppia di insiemi \(E,V\) dotati di due funzioni \(s,t : E\rightrightarrows V\) che associano ad ogni \emph{lato} \(e\in E\) una coppia ordinata di \emph{vertici} \(s(e),t(e)\in V\) detti il suo dominio o \emph{source} e il suo codominio o \emph{target}, si veda \ref{ex_cat_grafi}. Dato un multidigrafo \(\ctG\) (spesso chiamato semplicemente \emph{grafo diretto}) possiamo definire la \emph{categoria libera} \(F\ctG\) su \(\ctG\) come segue:
 	\begin{itemize}
 		\item gli oggetti di \(F\ctG\) sono esattamente gli elementi di \(V\);
-		\item fissati due vertici \(u,v\in V\), i morfismi \(u\to v\) sono l'insieme
-		\[\sum_{n\ge0} E(u,x_1)\times E(x_1,x_2)\times\dots\times E(x_n,v)\]
-		di tutte le sequenze ordinate e finite di lati
-		\[ [e_n;\dots;e_1] : u \xto{e_1} x_1 \xto{e_2} x_2\xto{e_3} \dots\xto{e_{n-1}} x_{n-1}\xto{e_n} v\]
-		con la convenzione di scrivere gli elementi della sequenza in ordine inverso\footnote{Questa convenzione segue quella che applica le funzioni `a sinistra', scrivendo $(f(g(x)) = (f\circ g)(x)$, si veda \ref{sulla_compo}.} ed intepretando il caso \(u=v,n=0\) come una sequenza fatta da un laccio `banale' \(\emptyList_u : u\to u\); in più, usiamo la notazione ovvia, \(E(x,y)\subseteq E\) per denotare i lati del grafo di dominio \(x\) e codominio \(y\).
+		\item dati \(u,v\in V\), i morfismi da \(u\) a \(v\) sono i cammini nel grafo diretto che partono da \(u\) e arrivano in \(v\):
+		\[\xymatrix{u \ar[r]^{e_1}& x_1 \ar[r]^{e_2}& x_2\ar[r]^{e_3}& \dots\ar[r]^{e_{n-1}}& x_{n-1}\ar[r]^{e_n}& v}.\]
+		Più precisamente, per ogni \(n>0\), sia \(C_n\) l'insieme dei cammini di lunghezza \(n>0\)
+		\[C_n=\{(e_1,\ldots,e_n)\in E^n \mid t(e_k)=s(e_{k+1}), k=1,\ldots,n-1\}\]
+		e sia \(C_0=\{\emptyList_u \mid u\in V\}\) l'insieme dei cammini di lunghezza zero.
+		L'insieme dei morfismi di \(F\ctG\) è
+		\[\sum_{n\ge0}C_n\]
+		Il dominio e codominio di una sequenza \((e_1,\ldots,e_n)\) di lunghezza  \(n>0\) sono rispettivamente \(s(e_1)\) e \(t(e_n)\).
+		Il dominio e codominio di un cammino \(\emptyList_u\) di lunghezza zero sono entrambi il vertice \(u\) stesso.
+%		fissati due vertici \(u,v\in V\), i morfismi \(u\to v\) sono l'insieme
+%		\[\sum_{n\ge0} E(u,x_1)\times E(x_1,x_2)\times\dots\times E(x_n,v)\]
+%		di tutte le sequenze ordinate e finite di lati
+%		\[ [e_n;\dots;e_1] : u \xto{e_1} x_1 \xto{e_2} x_2\xto{e_3} \dots\xto{e_{n-1}} x_{n-1}\xto{e_n} v\]
+%		con la convenzione di scrivere gli elementi della sequenza in ordine inverso\footnote{Questa convenzione segue quella che applica le funzioni `a sinistra', scrivendo $(f(g(x)) = (f\circ g)(x)$, si veda \ref{sulla_compo}.} ed intepretando il caso \(u=v,n=0\) come una sequenza fatta da un laccio `banale' \(\emptyList_u : u\to u\); in più, usiamo la notazione ovvia, \(E(x,y)\subseteq E\) per denotare i lati del grafo di dominio \(x\) e codominio \(y\).
 	\end{itemize}
-	La composizione di due sequenze \([f_m;\dots;f_1]\) e \([e_n;\dots;e_1]\) è data dalla loro \emph{concatenazione}, ossia dalla operazione
-	\[[f_m;\dots;f_1]\cmp[e_n;\dots;e_1] = [f_m;\dots;f_1;e_n;\dots;e_1].\]
+	La composizione di due sequenze \((f_1,\dots,f_m)\) e \((e_1,\dots,e_n)\) è data dalla loro \emph{concatenazione}, ossia dalla operazione
+	\[(f_1,\dots,f_m)\cmp(e_1,\dots,e_n) = (e_1,\dots,e_n,f_1,\dots,f_m).\]
 	Quando è definita, questa operazione è, evidentemente, associativa, e la sequenza vuota $\emptyList_u$ soddisfa l'assioma di identità \ref{cp_1} nella \ref{def_categ}.
  \begin{figure}
      %\centering

--- a/itaca.sty
+++ b/itaca.sty
@@ -243,7 +243,7 @@
 \newcommand{\eqv}{\simeq}
 
 \newcommand{\defeq}{\coloneqq}
-\newcommand{\emptyList}{[\;]}
+\newcommand{\emptyList}{(\,)}
 \NewDocumentCommand{\tup}{O{1} m m m}{
 #2_{#1} #4 \dots #4 #2_{#3}
 }


### PR DESCRIPTION
fix #27 

Mi sono permesso di modificare anche la notazione: non sono sicuro che invertire le liste aiuti. Ma possiamo facilmente reintrodurre l'inversione e le parentesi quadre.